### PR TITLE
Shortened the nights path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'nights#new'
   devise_for :users
   root to: 'pages#home'
-  resources :nights, only: [:create, :show]
+  resources :nights, only: :create
+  get '/:id', to: 'nights#show', as: :night
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Changed the routes so you can now access a night with a shorter URL.
bar-roulette.com/nights/:id
is now
bar-roulette.com/:id